### PR TITLE
Do not allow ':' in unquoted strings

### DIFF
--- a/pyarn/lexer.py
+++ b/pyarn/lexer.py
@@ -37,13 +37,13 @@ def t_NUMBER(t):
 
 # Unquoted string regex (see t_STRING)
 # Docstrings cannot use string interpolation, this value is used by other modules
-UNQUOTED_STRING = r'[a-zA-Z/.-]([^\s\n,]*[^\s\n,:])?'
+UNQUOTED_STRING = r'[a-zA-Z/.-][^\s\n,:]*'
 
 
 # TODO: handle final escaped quotes
 # Do this first to catch strings with spaces within
 def t_STRING(t):
-    r'"[^"\n]*"|[a-zA-Z/.-]([^\s\n,]*[^\s\n,:])?'
+    r'"[^"\n]*"|[a-zA-Z/.-][^\s\n,:]*'
     if t.value.startswith('"'):
         t.value = t.value[1:-1]
     elif t.value == 'true':

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -86,6 +86,8 @@ from pyarn import lexer
         ('foo "false"', ['STRING', 'STRING'], ['foo', 'false']),
         ('foo false', ['STRING', 'BOOLEAN'], ['foo', False]),
         ('foo "true"', ['STRING', 'STRING'], ['foo', 'true']),
+        ('foo:bar:', ['STRING', 'COLON', 'STRING', 'COLON'], ['foo', ':', 'bar', ':']),
+        ('"foo:bar":', ['STRING', 'COLON'], ['foo:bar', ':']),
     ],
 )
 def test_lexer(data, expected_types, expected_values):

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -146,7 +146,7 @@ def test_packages_checksum():
 
 
 def test_relpath():
-    data = 'breakfast@file:some/relative/path:\n  version "0.0.0"'
+    data = '"breakfast@file:some/relative/path":\n  version "0.0.0"'
     lock = lockfile.Lockfile.from_str(data)
     packages = lock.packages()
     assert len(packages) == 1
@@ -182,7 +182,11 @@ DATA_TO_DUMP = {
         'version': '2.0.0',
         'resolved': 'https://registry.yarnpkg.com/bar/-/bar-2.0.0.tgz',
         'some boolean': True,
-    }
+    },
+    'baz@https://example.org/baz.tar.gz': {
+        'version': '3.0.0',
+        'resolved': 'https://example.org/baz.tar.gz',
+    },
 }
 
 EXPECTED_CONTENT = dedent(
@@ -200,6 +204,10 @@ EXPECTED_CONTENT = dedent(
       version "2.0.0"
       resolved "https://registry.yarnpkg.com/bar/-/bar-2.0.0.tgz"
       "some boolean" true
+
+    "baz@https://example.org/baz.tar.gz":
+      version "3.0.0"
+      resolved "https://example.org/baz.tar.gz"
     """
 )
 


### PR DESCRIPTION
Pyarn considers ':' as part of a string token except at the end of a
string. In yarn, this is not the case. That can lead to some very
interesting bugs when using generated lockfiles with yarn.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>