### PR TITLE
Fix quoting of comma-separated keys

### DIFF
--- a/pyarn/lockfile.py
+++ b/pyarn/lockfile.py
@@ -114,12 +114,7 @@ class Lockfile():
 
 def _dump_keyval(key, value, outfile, indent_level):
     outfile.write(' ' * indent_level * 2)
-    if _needs_quoting(key):
-        # TODO: use json.dump to quote the key instead
-        #   (the lexer would also have to interpret strings using json.load)
-        outfile.write(f'"{key}"')
-    else:
-        outfile.write(key)
+    outfile.write(_quote_key_if_needed(key))
 
     if isinstance(value, dict):
         outfile.write(':\n')
@@ -131,11 +126,19 @@ def _dump_keyval(key, value, outfile, indent_level):
         outfile.write(' ')
         if isinstance(value, str):
             # Always quote string values
-            # TODO: see quoting keys
+            # TODO: use json.dump to quote the value instead
+            #   (the lexer would also have to interpret strings using json.load)
             outfile.write(f'"{value}"')
         else:
             json.dump(value, outfile)
         outfile.write('\n')
+
+
+def _quote_key_if_needed(key):
+    # The key may be a comma-separated list of keys
+    keys = map(str.strip, key.split(","))
+    # TODO: quote keys properly, see TODO about quoting values
+    return ", ".join(f'"{k}"' if _needs_quoting(k) else k for k in keys)
 
 
 def _needs_quoting(s):

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -187,6 +187,12 @@ DATA_TO_DUMP = {
         'version': '3.0.0',
         'resolved': 'https://example.org/baz.tar.gz',
     },
+    'spam@^4.0.0, spam@^4.0.1': {
+        'version': '4.0.0',
+    },
+    'eggs@file:some_file, eggs@file:other_file': {
+        'version': '5.0.0',
+    },
 }
 
 EXPECTED_CONTENT = dedent(
@@ -208,6 +214,12 @@ EXPECTED_CONTENT = dedent(
     "baz@https://example.org/baz.tar.gz":
       version "3.0.0"
       resolved "https://example.org/baz.tar.gz"
+
+    spam@^4.0.0, spam@^4.0.1:
+      version "4.0.0"
+
+    "eggs@file:some_file", "eggs@file:other_file":
+      version "5.0.0"
     """
 )
 


### PR DESCRIPTION
When a key is actually a list of comma-separated keys, the quotes should
not go around the entire list but around its individual members.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>