### PR TITLE
Correctly tokenize booleans

### DIFF
--- a/pyarn/lexer.py
+++ b/pyarn/lexer.py
@@ -35,6 +35,13 @@ def t_NUMBER(t):
     return t
 
 
+# Note: this must be defined BEFORE t_STRING, the grammar is ambiguous
+def t_BOOLEAN(t):
+    r'true|false'
+    t.value = (t.value == 'true')
+    return t
+
+
 # Unquoted string regex (see t_STRING)
 # Docstrings cannot use string interpolation, this value is used by other modules
 UNQUOTED_STRING = r'[a-zA-Z/.-][^\s\n,:]*'
@@ -46,12 +53,6 @@ def t_STRING(t):
     r'"[^"\n]*"|[a-zA-Z/.-][^\s\n,:]*'
     if t.value.startswith('"'):
         t.value = t.value[1:-1]
-    elif t.value == 'true':
-        t.value = True
-        t.type = 'BOOLEAN'
-    elif t.value == 'false':
-        t.value = False
-        t.type = 'BOOLEAN'
     return t
 
 

--- a/pyarn/lockfile.py
+++ b/pyarn/lockfile.py
@@ -142,4 +142,8 @@ def _quote_key_if_needed(key):
 
 
 def _needs_quoting(s):
+    if s.startswith('true') or s.startswith('false'):
+        # If a string starts with a boolean, it must be quoted no matter what
+        #   (otherwise, the string would be tokenized as BOOLEAN STRING)
+        return True
     return UNQUOTED_STRING_RE.fullmatch(s) is None

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -88,6 +88,9 @@ from pyarn import lexer
         ('foo "true"', ['STRING', 'STRING'], ['foo', 'true']),
         ('foo:bar:', ['STRING', 'COLON', 'STRING', 'COLON'], ['foo', ':', 'bar', ':']),
         ('"foo:bar":', ['STRING', 'COLON'], ['foo:bar', ':']),
+        ('true false', ['BOOLEAN', 'BOOLEAN'], [True, False]),
+        ('true-false', ['BOOLEAN', 'STRING'], [True, '-false']),
+        ('not-true', ['STRING'], ['not-true']),
     ],
 )
 def test_lexer(data, expected_types, expected_values):

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -193,6 +193,11 @@ DATA_TO_DUMP = {
     'eggs@file:some_file, eggs@file:other_file': {
         'version': '5.0.0',
     },
+    'true-case-path@^1.0.2': {
+        'dependencies': {
+            'true-case-path': '^2.0.1'
+        }
+    },
 }
 
 EXPECTED_CONTENT = dedent(
@@ -220,6 +225,10 @@ EXPECTED_CONTENT = dedent(
 
     "eggs@file:some_file", "eggs@file:other_file":
       version "5.0.0"
+
+    "true-case-path@^1.0.2":
+      dependencies:
+        "true-case-path" "^2.0.1"
     """
 )
 


### PR DESCRIPTION
CLOUDBLD-5359

Previously, pyarn would not tokenize booleans at the beginning of a
longer string. Example: 'true-case-path' (should be BOOLEAN STRING,
pyarn thought it was just one STRING).

Also make sure strings that start with booleans will be properly quoted
when generating a lockfile.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>