### PR TITLE
Raise error if yarn.lock contains a key with quoted comma

### DIFF
--- a/pyarn/parser.py
+++ b/pyarn/parser.py
@@ -57,13 +57,25 @@ def p_block_comment(p):
 def p_title(p):
     """title : STRING COLON INDENT
              | list COLON INDENT"""
+    if isinstance(p[1], str):
+        if ',' in p[1]:
+            raise ValueError(f'Following key has a quoted comma: "{p[1]}"')
+    else:
+        for key in p[1]:
+            if ',' in key:
+                raise ValueError(f'Following key has a quoted comma: "{key}"')
+        p[1] = ', '.join(p[1])
     p[0] = p[1]
 
 
 def p_list(p):
     """list : STRING COMMA STRING
             | list COMMA STRING"""
-    p[0] = ', '.join([p[1], p[3]])
+    if isinstance(p[1], str):
+        p[0] = [p[1], p[3]]
+    else:
+        p[1].append(p[3])
+        p[0] = p[1]
 
 
 def p_members(p):

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -59,6 +59,20 @@ def test_from_file():
     assert lock.data == expected
 
 
+@pytest.mark.parametrize(
+    'key, lockfile_str',
+    [
+        ('"foo, bar"', '"foo, bar":\n  version "1.0.0"'),
+        ('"foo, bar"', '"foo, bar", foo2:\n  version "1.0.0"'),
+        ('"foo, bar"', 'foo1, foo2, "foo, bar", foo3:\n  version "1.0.0"'),
+        ('"foo, bar"', 'foo:\n  version "1.0.0"\n"foo, bar":\n  version "1.0.0"'),
+    ]
+)
+def test_key_with_quoted_comma(key, lockfile_str):
+    with pytest.raises(ValueError, match=f'Following key has a quoted comma: {key}'):
+        lockfile.Lockfile.from_str(lockfile_str)
+
+
 def test_v1():
     lock = lockfile.Lockfile.from_str('# yarn lockfile v1\n')
     assert lock.version == '1'


### PR DESCRIPTION
CLOUDBLD-4216

Signed-off-by: Sumin Cho <sucho@redhat.com>

In pyarn, comma(s) in a quoted key causes an unexpected error:

**Before parsing (string):**
`"foo, bar":\n   some_key some_val`

**After parsing (dict):**
`{"foo, bar": {"some_key": "some_value"}}`

When not inside quotes, it is functional for keys to have commas in between; this acts as a separator which can be used to specify multiple keys on the same line.

Since quoted commas cause complications and there are simple workaround this notation, I thought it was best to raise an error if a yarn.lock file contains key with quoted comma.
