### PR TITLE
Handle additional path-based version specifiers

### DIFF
--- a/pyarn/lockfile.py
+++ b/pyarn/lockfile.py
@@ -34,7 +34,15 @@ V1_VERSION_COMMENT = "# yarn lockfile v1"
 
 class Package:
     def __init__(
-        self, name, version, url=None, checksum=None, relpath=None, dependencies=None, alias=None
+        self,
+        name,
+        version,
+        url=None,
+        checksum=None,
+        path=None,
+        relpath=None,
+        dependencies=None,
+        alias=None,
     ):
         if not name:
             raise ValueError("Package name was not provided")
@@ -46,9 +54,29 @@ class Package:
         self.version = version
         self.url = url
         self.checksum = checksum
-        self.relpath = relpath
+        self.path = path if path is not None else relpath
         self.dependencies = dependencies or {}
         self.alias = alias
+
+    @property
+    def relpath(self) -> Optional[str]:
+        """
+        Return the path to the package.
+
+        This is strictly kept for backwards compatibility and path should be used directly
+        instead. The path is not always relative and may be absolute.
+        """
+        return self.path
+
+    @relpath.setter
+    def relpath(self, path: Optional[str]) -> None:
+        """
+        Set the path to the package.
+
+        This is strictly kept for backwards compatibility and path should be used directly
+        instead. The path is not always relative and may be absolute.
+        """
+        self.path = path
 
     @classmethod
     def from_dict(cls, raw_name, data):
@@ -71,7 +99,7 @@ class Package:
             version=data.get("version"),
             url=data.get("resolved"),
             checksum=data.get("integrity"),
-            relpath=path,
+            path=path,
             dependencies=data.get("dependencies", {}),
             alias=alias,
         )

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -120,7 +120,7 @@ def test_packages():
     assert packages[0].version == "2.0.0"
     assert packages[0].checksum is None
     assert packages[0].url is None
-    assert packages[0].relpath is None
+    assert packages[0].path is None
 
 
 def test_packages_no_version():
@@ -145,7 +145,7 @@ def test_packages_url():
     assert packages[0].version == "2.0.0"
     assert packages[0].checksum is None
     assert packages[0].url == url
-    assert packages[0].relpath is None
+    assert packages[0].path is None
 
 
 def test_packages_checksum():
@@ -158,10 +158,10 @@ def test_packages_checksum():
     assert packages[0].version == "2.0.0"
     assert packages[0].checksum == "someHash"
     assert packages[0].url == url
-    assert packages[0].relpath is None
+    assert packages[0].path is None
 
 
-def test_relpath():
+def test_path():
     data = '"breakfast@file:some/relative/path":\n  version "0.0.0"'
     lock = lockfile.Lockfile.from_str(data)
     packages = lock.packages()
@@ -170,7 +170,8 @@ def test_relpath():
     assert packages[0].version == "0.0.0"
     assert packages[0].checksum is None
     assert packages[0].url is None
-    assert packages[0].relpath == "some/relative/path"
+    assert packages[0].path == "some/relative/path"
+    assert packages[0].relpath == "some/relative/path"  # test backwards compatibility
 
 
 def test_package_with_comma():
@@ -182,7 +183,7 @@ def test_package_with_comma():
     assert packages[0].version == "1.1.7"
     assert packages[0].checksum is None
     assert packages[0].url is None
-    assert packages[0].relpath is None
+    assert packages[0].path is None
 
 
 DATA_TO_DUMP = {
@@ -298,19 +299,19 @@ def test_aliased_packages(test_data_dir: Path):
     assert babel.name == "babel-plugin-add-module-exports"
     assert babel.alias == "babel7-plugin-add-module-exports"
     assert babel.version == "1.0.0"
-    assert babel.relpath is None
+    assert babel.path is None
 
     assert lodash.name == "@elastic/lodash"
     assert lodash.alias == "lodash"
     assert lodash.version == "3.10.1-kibana1"
-    assert lodash.relpath is None
+    assert lodash.path is None
 
     assert fecha.name == "fecha"
     assert fecha.alias == "date-in-spanish"
     assert fecha.version == "4.2.3"
-    assert fecha.relpath is None
+    assert fecha.path is None
 
     assert nonsense.name == "what"
     assert nonsense.alias == "probably-nonsense"
     assert nonsense.version == "0.0.1"
-    assert nonsense.relpath == "how"
+    assert nonsense.path == "how"

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -123,16 +123,21 @@ def test_packages():
     assert packages[0].path is None
 
 
-def test_packages_no_version():
+def test_lock_packages_no_version():
     data = "breakfast@^1.1.1:\n  eggs bacon"
     lock = lockfile.Lockfile.from_str(data)
     with pytest.raises(ValueError, match="Package version was not provided"):
         lock.packages()
 
 
+def test_package_no_version():
+    with pytest.raises(ValueError, match="Package version was not provided"):
+        lockfile.Package("breakfast", None)  # type: ignore[arg-type]
+
+
 def test_packages_no_name():
     with pytest.raises(ValueError, match="Package name was not provided"):
-        lockfile.Package(None, "1.0.0")
+        lockfile.Package(None, "1.0.0")  # type: ignore[arg-type]
 
 
 def test_packages_url():

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -161,8 +161,37 @@ def test_packages_checksum():
     assert packages[0].path is None
 
 
-def test_path():
-    data = '"breakfast@file:some/relative/path":\n  version "0.0.0"'
+@pytest.mark.parametrize(
+    "data, expected_path",
+    [
+        pytest.param(
+            '"breakfast@file:some/relative/path":\n  version "0.0.0"',
+            "some/relative/path",
+            id="relpath_with_file_prefix",
+        ),
+        pytest.param(
+            '"breakfast@link:some/relative/path":\n  version "0.0.0"',
+            "some/relative/path",
+            id="relpath_with_link_prefix",
+        ),
+        pytest.param(
+            '"breakfast@./some/relative/path":\n  version "0.0.0"',
+            "some/relative/path",
+            id="relpath_with_dot_prefix",
+        ),
+        pytest.param(
+            '"breakfast@../some/relative/path":\n  version "0.0.0"',
+            "../some/relative/path",
+            id="relpath_to_parent_dir",
+        ),
+        pytest.param(
+            '"breakfast@/some/absolute/path":\n  version "0.0.0"',
+            "/some/absolute/path",
+            id="absolute_path",
+        ),
+    ],
+)
+def test_package_with_path(data: str, expected_path: str) -> None:
     lock = lockfile.Lockfile.from_str(data)
     packages = lock.packages()
     assert len(packages) == 1
@@ -170,8 +199,8 @@ def test_path():
     assert packages[0].version == "0.0.0"
     assert packages[0].checksum is None
     assert packages[0].url is None
-    assert packages[0].path == "some/relative/path"
-    assert packages[0].relpath == "some/relative/path"  # test backwards compatibility
+    assert packages[0].path == expected_path
+    assert packages[0].relpath == expected_path  # test backwards compatibility
 
 
 def test_package_with_comma():


### PR DESCRIPTION
Add handling for more path-based version specifiers
    
These are all valid version specifiers for path-style packages in package.json/yarn.lock:

./some/relative/path
../some/relative/path
file:some/relative/path
file:../some/relative/path
link:some/relative/path
link:../some/relative/path\
/some/absolute/path

Ensure that the Package class provides a path in each of these cases.