### PR TITLE
Bump project version to 0.3.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pyarn
-version = 0.2.0
+version = 0.3.0
 description = Yarn JS package manager lockfile parser
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Version 0.3.0 contains handling for additional path-based version specifiers in yarn.lock.